### PR TITLE
Add ScreenshotOne integration for portfolio images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables
+POSTGRES_URL=
+GIT_API_KEY=
+VERCEL_TOKEN=
+SCREENSHOTONE_KEY=3eEMm5mnfH7zJA

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+### Portfolio screenshots
+
+This project uses [ScreenshotOne](https://screenshotone.com) to generate images of portfolio projects. Screenshots are fetched using the `SCREENSHOTONE_KEY` environment variable and downloaded to the `public` folder so subsequent requests do not consume the API quota.
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.

--- a/src/app/lib/data.ts
+++ b/src/app/lib/data.ts
@@ -2,6 +2,7 @@ import { PrismaClient } from '@prisma/client'
 import apiError from './utils'
 import { Portfolio } from './definitions'
 import { unstable_noStore as noStore } from 'next/cache'
+import { ensureScreenshot } from './screenshot'
 
 const prisma = new PrismaClient()
 
@@ -127,6 +128,14 @@ export async function fectchPortfolio() {
         },
       )
     }) as Portfolio[]
+
+    for (const repo of data) {
+      try {
+        await ensureScreenshot(repo.homepage, repo.name.toLowerCase())
+      } catch (e) {
+        console.error('Screenshot error:', e)
+      }
+    }
 
     return { data, ok: true, error: '' }
   } catch (error) {

--- a/src/app/lib/screenshot.ts
+++ b/src/app/lib/screenshot.ts
@@ -1,0 +1,22 @@
+import fs from 'fs/promises'
+import path from 'path'
+
+const ACCESS_KEY = process.env.SCREENSHOTONE_KEY ?? '3eEMm5mnfH7zJA'
+
+export async function ensureScreenshot(url: string, fileName: string) {
+  const filePath = path.join(process.cwd(), 'public', `${fileName}.png`)
+  try {
+    await fs.access(filePath)
+    return
+  } catch {
+    // File does not exist; download it
+  }
+
+  const shotUrl = `https://api.screenshotone.com/take?access_key=${ACCESS_KEY}&url=${encodeURIComponent(url)}&format=png&download=1`
+  const res = await fetch(shotUrl)
+  if (!res.ok) {
+    throw new Error('Failed to download screenshot')
+  }
+  const arrayBuffer = await res.arrayBuffer()
+  await fs.writeFile(filePath, Buffer.from(arrayBuffer))
+}


### PR DESCRIPTION
## Summary
- cache portfolio screenshots with ScreenshotOne API
- document ScreenshotOne usage in README
- add `.env.example` with new SCREENSHOTONE_KEY

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6886eee5034483258566cde025801b8c