### PR TITLE
Improve hero loading experience with image skeleton and placeholders

### DIFF
--- a/src/app/components/HeroData.tsx
+++ b/src/app/components/HeroData.tsx
@@ -10,6 +10,7 @@ type HeroDataProps = {
   bio: string | null
   handleTypewriterEnd: () => void
   showAll: boolean
+  isLoading: boolean
 }
 
 export default function HeroData({
@@ -18,8 +19,20 @@ export default function HeroData({
   bio,
   handleTypewriterEnd,
   showAll,
+  isLoading,
 }: HeroDataProps) {
   const router = useRouter()
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col flex-1-1-42 items-center">
+        <div className="h-20 w-72 md:w-96 rounded-full bg-gray4/80 animate-pulse mb-6" />
+        <div className="h-12 w-48 md:w-72 rounded-full bg-gray4/80 animate-pulse mb-6" />
+        <div className="h-24 w-full max-w-xl rounded-3xl bg-gray4/80 animate-pulse mb-6" />
+        <div className="h-16 w-48 rounded-full bg-gray4/80 animate-pulse" />
+      </div>
+    )
+  }
 
   return (
     <div className="flex flex-col flex-1-1-42 items-center">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -119,6 +119,19 @@ h1, h2, h3 {
   animation: skeleton 1.5s infinite linear;
 }
 
+.home-img-skeleton {
+  height: 70%;
+  width: 70%;
+  border-radius: 30% 70% 70% 30%/30% 30% 70% 70%;
+}
+
+@media (max-width: 768px) {
+  .home-img-skeleton {
+    height: 30rem;
+    width: 30rem;
+  }
+}
+
 
 @keyframes skeleton {
   from {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -70,8 +70,8 @@ h1, h2, h3 {
 }
 
 .home-img {
-  height: 70%;
   width: 70%;
+  height: auto;
   border-radius: 30% 70% 70% 30%/30% 30% 70% 70%;
 }
 
@@ -99,8 +99,8 @@ h1, h2, h3 {
 
 @media (max-width: 768px) {
   .home-img {
-    height: 30rem;
     width: 30rem;
+    height: auto;
   }
 }
 
@@ -120,15 +120,15 @@ h1, h2, h3 {
 }
 
 .home-img-skeleton {
-  height: 70%;
   width: 70%;
+  aspect-ratio: 1 / 1;
   border-radius: 30% 70% 70% 30%/30% 30% 70% 70%;
 }
 
 @media (max-width: 768px) {
   .home-img-skeleton {
-    height: 30rem;
     width: 30rem;
+    aspect-ratio: 1 / 1;
   }
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,8 +11,14 @@ interface UserData {
 }
 
 export default function Home() {
-  const [data, setData] = useState<UserData | null>(null)
+  const [data, setData] = useState<UserData>({
+    name: '',
+    bio: '',
+    skill: '',
+  })
+  const [isDataLoaded, setIsDataLoaded] = useState(false)
   const [showAll, setShowAll] = useState(false)
+  const [imageLoaded, setImageLoaded] = useState(false)
 
   const handleTypewriterEnd = () => {
     setShowAll(true)
@@ -20,42 +26,48 @@ export default function Home() {
 
   useEffect(() => {
     fetchUserData().then((result) => {
-      if (result && result.name && result.bio && result.skill) {
-        setData({
-          name: result.name ?? '',
-          bio: result.bio ?? '',
-          skill: result.skill ?? '',
-        })
-      } else {
-        setData(null)
-      }
+      setData({
+        name: result?.name ?? '',
+        bio: result?.bio ?? '',
+        skill: result?.skill ?? '',
+      })
+      setIsDataLoaded(true)
     })
   }, [])
 
   return (
     <section className="flex items-center flex-wrap gap-8 md:gap-16 home-min-height text-center md:text-left">
-      {data && (
-        <>
-          <div className="flex justify-center text-center flex-1-1-42">
-            <Image
-              src="/17189429960332.jpg"
-              alt="Foto de perfil"
-              width={1024}
-              height={1024}
-              priority
-              loading="eager"
-              className="home-img motion-preset-expand"
+      <div className="flex justify-center text-center flex-1-1-42">
+        <div className="relative flex items-center justify-center w-full">
+          {!imageLoaded && (
+            <div
+              className="home-img-skeleton skeleton absolute"
+              aria-hidden="true"
             />
-          </div>
-          <HeroData
-            name={data.name}
-            bio={data.bio}
-            skill={data.skill}
-            handleTypewriterEnd={handleTypewriterEnd}
-            showAll={showAll}
+          )}
+          <Image
+            src="/17189429960332.jpg"
+            alt="Foto de perfil"
+            width={1024}
+            height={1024}
+            priority
+            loading="eager"
+            sizes="(min-width: 768px) 42vw, 70vw"
+            onLoad={() => setImageLoaded(true)}
+            className={`home-img motion-preset-expand transition-opacity duration-700 ${
+              imageLoaded ? 'opacity-100' : 'opacity-0'
+            }`}
           />
-        </>
-      )}
+        </div>
+      </div>
+      <HeroData
+        name={data.name}
+        bio={data.bio}
+        skill={data.skill}
+        handleTypewriterEnd={handleTypewriterEnd}
+        showAll={showAll}
+        isLoading={!isDataLoaded}
+      />
     </section>
   )
 }


### PR DESCRIPTION
### Motivation
- Prevent a blank hero area while profile image and remote data load by showing placeholders.
- Ensure the image fade-in animation runs when the photo finishes loading instead of blocking text animation.
- Let the text/typewriter animation run independently from image load so content feels responsive.

### Description
- Initialize `data` with empty fields and add `isDataLoaded` and `imageLoaded` state in `src/app/page.tsx`.
- Render an image skeleton (`.home-img-skeleton`) and use `onLoad` to set `imageLoaded` and fade the image in with `transition-opacity` and `sizes` on the `Image` component.
- Add an `isLoading` prop to `HeroData` and show pulse placeholders while data is loading in `src/app/components/HeroData.tsx`.
- Add CSS for `.home-img-skeleton` to `src/app/globals.css` and keep existing `skeleton` animation for placeholders.

### Testing
- Ran `npm run dev` which compiled, but font download from Google Fonts failed and fell back to system fonts.
- Dev server encountered `PrismaClientInitializationError` due to missing `POSTGRES_URL`, causing data fetch failures during runtime.
- Executed a Playwright script to visit `http://127.0.0.1:3000` and capture a screenshot to `artifacts/home.png`, which completed successfully.
- No additional automated unit tests were added or executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952824b4420832595f1a336d8a2db26)